### PR TITLE
chore: add vue hyphenation ignores for Cientos Sky

### DIFF
--- a/packages/eslint-config-vue/index.js
+++ b/packages/eslint-config-vue/index.js
@@ -135,7 +135,13 @@ module.exports = {
     'vue/space-unary-ops': ['error', { words: true, nonwords: false }],
     'vue/template-curly-spacing': 'error',
     'vue/attribute-hyphenation': [2, 'always', {
-      ignore: ['shadow-mapSize-width', 'shadow-mapSize-height'],
+      ignore: [
+        'shadow-mapSize-width',
+        'shadow-mapSize-height',
+        'material-uniforms-mieCoefficient-value',
+        'material-uniforms-mieDirectionalG-value',
+        'material-uniforms-sunPosition-value',
+      ],
     }],
   },
 }


### PR DESCRIPTION
Following [this discussion about the linter breaking Cientos Sky](https://github.com/Tresjs/cientos/pull/213#issuecomment-1721224302), this PR adds the ignores for the Vue attributes required by the Sky component.

## Note

This is a specific fix for the Sky component.

It does not solve the larger issue of the linter breaking Three/GLSL uniforms. 



